### PR TITLE
Removing empty pars from config generator script

### DIFF
--- a/python/listrev/app_confgen.py
+++ b/python/listrev/app_confgen.py
@@ -86,17 +86,15 @@ def generate(
     jstr = json.dumps(startcmd.pod(), indent=4, sort_keys=True)
     print("="*80+"\nStart\n\n", jstr)
 
-    emptypars = rc.EmptyParams()
-
     stopcmd = mrccmd("stop", "RUNNING", "CONFIGURED", [
-            (".*", emptypars),
+            (".*", None),
         ])
 
     jstr = json.dumps(stopcmd.pod(), indent=4, sort_keys=True)
     print("="*80+"\nStop\n\n", jstr)
 
     scrapcmd = mrccmd("scrap", "CONFIGURED", "INITIAL", [
-            (".*", emptypars)
+            (".*", None)
         ])
 
     jstr = json.dumps(scrapcmd.pod(), indent=4, sort_keys=True)


### PR DESCRIPTION
Not required any longer.