### PR TITLE
Switching to opmon templates for info structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ daq_setup_environment()
 
 find_package(rcif REQUIRED)
 find_package(appfwk REQUIRED)
+find_package(opmonlib REQUIRED)
 
-daq_codegen(*.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( randomdatalistgenerator.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+daq_codegen( randomdatalistgeneratorinfo.jsonnet DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2 )
 
 daq_add_plugin(ListReverser duneDAQModule	     LINK_LIBRARIES appfwk::appfwk)
 daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES appfwk::appfwk)

--- a/plugins/RandomDataListGenerator.cpp
+++ b/plugins/RandomDataListGenerator.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "listrev/randomdatalistgenerator/Nljs.hpp"
-#include "listrev/randomdatalistgeneratorinfo/Nljs.hpp"
+#include "listrev/randomdatalistgeneratorinfo/InfoNljs.hpp"
 
 #include "CommonIssues.hpp"
 #include "RandomDataListGenerator.hpp"

--- a/schema/listrev/randomdatalistgeneratorinfo.jsonnet
+++ b/schema/listrev/randomdatalistgeneratorinfo.jsonnet
@@ -4,13 +4,10 @@ local moo = import "moo.jsonnet";
 local s = moo.oschema.schema("dunedaq.listrev.randomdatalistgeneratorinfo");
 
 local info = {
-   cl : s.string("class_s", moo.re.ident,
-                  doc="A string field"), 
     uint8  : s.number("uint8", "u8",
-                     doc="An unsigned of 8 bytes"),
+        doc="An unsigned of 8 bytes"),
 
    info: s.record("Info", [
-       s.field("class_name", self.cl, "randomdatalistgeneratorinfo", doc="Info class name"),
        s.field("generated_numbers", self.uint8, 0, doc="Counting generated numbers"), 
        s.field("new_generated_numbers", self.uint8, 0, doc="Counting incrementally generated numbers"), 
    ], doc="List generator information information")


### PR DESCRIPTION
This PR switches listrev to using opmon info templates.

