### PR TITLE
removed unused CLOCK_SPEED_HZ variable

### DIFF
--- a/scripts/commtest_gen
+++ b/scripts/commtest_gen
@@ -13,8 +13,6 @@ from daqconf.core.conf_utils import make_app_command_data
 from daqconf.core.metadata import write_metadata_file
 from daqconf.core.config_file import generate_cli_from_schema
 
-CLOCK_SPEED_HZ = 50000000
-
 # Add -h as default help option
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 

--- a/scripts/listrev_gen
+++ b/scripts/listrev_gen
@@ -13,8 +13,6 @@ from daqconf.core.conf_utils import make_app_command_data
 from daqconf.core.metadata import write_metadata_file
 from daqconf.core.config_file import generate_cli_from_schema
 
-CLOCK_SPEED_HZ = 50000000
-
 # Add -h as default help option
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 


### PR DESCRIPTION
The full set of repositories that are affected by this change is contained in the following list

```
git clone https://github.com/DUNE-DAQ/daqconf.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dfmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/dqm.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/flxlibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hdf5libs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/hsilibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/readoutmodules.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/timinglibs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/trigger.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/triggeralgs.git -b kbiery/62.5MHz_defaults
git clone https://github.com/DUNE-DAQ/wibmod.git -b kbiery/62.5MHz_defaults
```

Recall that this first step in the deprecation of legacy hardware is simply switching to a default clock frequency of 62.5 MHz in our scripts, etc.  More changes will come later.