### PR TITLE
renamed hardware_map_required to dro_map_required in listrev_test.py

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -20,8 +20,8 @@ expected_event_count=run_duration
 confgen_name="listrev_gen"
 # Don't require the --frame-file option, we don't need it
 frame_file_required=False
-# Don't create/require a hardware map file
-hardware_map_required=False
+# Don't create/require a detector readout map file
+dro_map_required=False
 # Determine if the Connectivity Service is available
 use_connectivity_service = True
 try:


### PR DESCRIPTION
The changes included in this Pull Request are related to changes on other repose related to the switch from HardwareMaps to DROMaps.

The full set of repos is the following:  `daqconf, daq-systemtest, dfmodules, lbrulibs, listrev, `and` integrationtest`.

More information about the changes, and instructions for how to test them, are included in the [daqconf PR (number 295)](https://github.com/DUNE-DAQ/dfmodules/pull/295).