### PR TITLE
Porting v4 changes to v5 - just the addition of the scale_listev_app script

### DIFF
--- a/scripts/scale_listrev_app
+++ b/scripts/scale_listrev_app
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import json
+import shutil
+import click
+from os.path import exists, join, dirname
+from os import remove
+from rich.console import Console
+
+console = Console()
+
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--num-apps', '-n', type=int, default=10, help="The number of listrev apps to create")
+@click.argument('listrev_cfg_dir', type=click.Path(exists=True))
+def cli(num_apps, listrev_cfg_dir):
+
+    if not exists(listrev_cfg_dir):
+        raise RuntimeError(f"Directory {listrev_cfg_dir} does not exist")
+
+    console.print(f'Duplicating {listrev_cfg_dir} to have {num_apps} listrev applications')
+
+    boot_json = join(listrev_cfg_dir, 'boot.json')
+    with open(boot_json) as file:
+        data = json.load(file)
+
+    new_apps = {}
+    new_order = []
+
+    for i in range(num_apps):
+        new_apps[f'listrev-app-s-{i}'] = data['apps']['listrev-app-s']
+        new_order.append(f'listrev-app-s-{i}')
+        shutil.copy(join(listrev_cfg_dir, 'data', 'listrev-app-s_conf.json'), join(listrev_cfg_dir, 'data', f'listrev-app-s-{i}_conf.json'))
+        shutil.copy(join(listrev_cfg_dir, 'data', 'listrev-app-s_init.json'), join(listrev_cfg_dir, 'data', f'listrev-app-s-{i}_init.json'))
+
+    remove(join(listrev_cfg_dir, 'data', f'listrev-app-s_conf.json'))
+    remove(join(listrev_cfg_dir, 'data', f'listrev-app-s_init.json'))
+
+    data['apps']  = new_apps
+    data['order'] = new_order
+
+    remove(boot_json)
+
+    with open(boot_json, 'w') as file:
+        json.dump(data, file, indent=4)
+
+
+if __name__ == '__main__':
+    try:
+        cli()
+    except Exception as e:
+        console.print_exception()


### PR DESCRIPTION
The goal of this Pull Request is to bring changes that were only made in the v4 line of development into the v5 line.

In this repo (`listrev`), the only change that was made on the v4 line after v5 work started was the addition of the `scale_list_app` script.  

I have verified that the automated integration test in this repo (`listrev_test.py`) continues to work after this change (not surprising).

However, I have **_not_** verified that the `scale_listrev_app` script continues to provide the same functionality in v5 that it provided in v4, and that is the testing that I'm requesting from the reviewer(s).
