### PR TITLE
JCF: ignore SIGHUP error message gunicorn introduced between 21.1.0 a…

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -27,6 +27,7 @@ excluded_substring_map = {
     "local-connection-server": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal",
+        "Worker.*was sent SIGHUP"
     ],
     "listrev": ["connect: Connection refused"]
 }


### PR DESCRIPTION
…nd 23.0.0 (see https://github.com/DUNE-DAQ/daq-release/wiki/Externals-Survey for more)