### PR TITLE
Johnfreeman/new daq cmake for v5.3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,15 @@ find_package(opmonlib REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(confmodel REQUIRED)
 
-daq_oks_codegen(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
+add_dal_library(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( listreverser.jsonnet randomdatalistgenerator.jsonnet reversedlistvalidator.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2)
 daq_protobuf_codegen( opmon/*.proto )
 
 daq_add_library(ListCreator.cpp ListStorage.cpp LINK_LIBRARIES  appfwk::appfwk confmodel::confmodel)
 
-daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev)
-daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev)
-daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev)
+daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev dal_listrev)
+daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev dal_listrev)
+daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev dal_listrev)
 
 daq_install()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,15 @@ find_package(opmonlib REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(confmodel REQUIRED)
 
-add_dal_library(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
+daq_add_dal_library(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( listreverser.jsonnet randomdatalistgenerator.jsonnet reversedlistvalidator.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2)
 daq_protobuf_codegen( opmon/*.proto )
 
 daq_add_library(ListCreator.cpp ListStorage.cpp LINK_LIBRARIES  appfwk::appfwk confmodel::confmodel)
 
-daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev dal_listrev)
-daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev dal_listrev)
-daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev dal_listrev)
+daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev listrev_dal)
+daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev listrev_dal)
+daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev listrev_dal)
 
 daq_install()


### PR DESCRIPTION
The following PR enables this package to build on its patch branch against `daq-cmake` `v3.1.0`, which contains changes described in DUNE-DAQ/daq-cmake#155. 

This is only to be merged by Software Coordination. 