### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc3 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,15 @@ find_package(opmonlib REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(confmodel REQUIRED)
 
-daq_oks_codegen(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
+add_dal_library(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( listreverser.jsonnet randomdatalistgenerator.jsonnet reversedlistvalidator.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2)
 daq_protobuf_codegen( opmon/*.proto )
 
 daq_add_library(ListCreator.cpp ListStorage.cpp LINK_LIBRARIES  appfwk::appfwk confmodel::confmodel)
 
-daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev)
-daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev)
-daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev)
+daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev dal_listrev)
+daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev dal_listrev)
+daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev dal_listrev)
 
 daq_install()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(listrev VERSION 5.0.0)
+project(listrev VERSION 5.0.1)
 
 find_package(daq-cmake REQUIRED )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,15 @@ find_package(opmonlib REQUIRED)
 find_package(oksdalgen REQUIRED)
 find_package(confmodel REQUIRED)
 
-add_dal_library(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
+daq_add_dal_library(listrev.schema.xml NAMESPACE dunedaq::listrev::dal DALDIR dal DEP_PKGS confmodel)
 
 daq_codegen( listreverser.jsonnet randomdatalistgenerator.jsonnet reversedlistvalidator.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2)
 daq_protobuf_codegen( opmon/*.proto )
 
 daq_add_library(ListCreator.cpp ListStorage.cpp LINK_LIBRARIES  appfwk::appfwk confmodel::confmodel)
 
-daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev dal_listrev)
-daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev dal_listrev)
-daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev dal_listrev)
+daq_add_plugin(ListReverser            duneDAQModule LINK_LIBRARIES listrev listrev_dal)
+daq_add_plugin(RandomDataListGenerator duneDAQModule LINK_LIBRARIES listrev listrev_dal)
+daq_add_plugin(ReversedListValidator   duneDAQModule LINK_LIBRARIES listrev listrev_dal)
 
 daq_install()


### PR DESCRIPTION
This PR is part of an overall merging of the `patch/fddaq-v5.3.x` branches into `develop` in the wake of release candidate 3 for `fddaq-v5.3.2`; note that the actual source branch, `johnfreeman/merge_fddaq-v5.3.2-rc3-a9_into_develop`, is an intermediary here. A test release was built with the source branch (`NFDT_DEV_250617_A9`) and successful integration tests were run (https://github.com/DUNE-DAQ/daq-release/actions/runs/15717205217). 