### PR TITLE
JCF: bump the single repo CI workflow so that it runs when a PR is op…

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -12,7 +12,11 @@ on:
       - 'docs/**'
       - '.github/**'
   pull_request:
-    branches: [ develop ]
+    branches:
+      - develop
+      - patch/*
+      - prep-release/*
+
   schedule:
     - cron: "0 9 * * *"
 


### PR DESCRIPTION
…ened into prep-release or patch branches (see https://github.com/DUNE-DAQ/.github/issues/4 and https://github.com/DUNE-DAQ/.github/pull/5 for details)