### PR TITLE
Adapt config to connectivityserver renaming

### DIFF
--- a/config/listrev-objects.data.xml
+++ b/config/listrev-objects.data.xml
@@ -91,7 +91,7 @@
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
   <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
-  <data val="gunicorn -b 0.0.0.0:25000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connection-service.connection-flask:app"/>
+  <data val="gunicorn -b 0.0.0.0:25000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>


### PR DESCRIPTION
Relies on https://github.com/DUNE-DAQ/connectivityserver/pull/24