### PR TITLE
Added a SIGHUP message to the list of ignored messages in the integtest.

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -23,11 +23,12 @@ excluded_substring_map = {
         'ERROR.*Broadcast:.*Propagating describe to children',
         'WARNING.*Broadcast:.*There is no broadcasting service!',
         "Worker with pid \\d+ was terminated due to signal",
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PP/JCF
     ],
     "local-connection-server": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal",
-        "Worker.*was sent SIGHUP"
+        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PP/JCF
     ],
     "listrev": ["connect: Connection refused"]
 }


### PR DESCRIPTION
# Description

Recently, Pawel and John noticed that we occasionally see messages like the following in regression tests:

```
[ERROR] Worker (pid:3925714) was sent SIGHUP!
```

Some of the existing regression tests exclude messages like this when searching log files for errors and warnings, while others don't.

Pawel investigated the source of these messages and made some progress, but his preference is to defer a full investigation until after `fddaq-v5.5.0`.  Given that, we believe that it is prudent to add messages of this type to the ignored message lists in all regression tests.  This PR does that for the `listrev` repo.

These changes are independent of all other changes.

To test this in the short term, we should verify that the regression tests run without problems.  In the medium term (after this PR is approved and merged), we should watch that we don't see instances of the SIGHUP in regression tests.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

I have confirmed that existing tests run fine for me.

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
