### PR TITLE
Avoid SIGHUP error message in connectivity server log file

### DIFF
--- a/config/listrev-objects.data.xml
+++ b/config/listrev-objects.data.xml
@@ -90,8 +90,8 @@
  <attr name="application_name" type="string" val="echo"/>
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
-  <data val="trap &apos;pkill -INT -P $$&apos; EXIT;"/>
-  <data val="gunicorn -b 0.0.0.0:25000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
+  <data val="trap &apos;pkill -QUIT -P $$&apos; EXIT;"/>
+  <data val="setsid gunicorn -b 0.0.0.0:25000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>

--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -28,7 +28,6 @@ excluded_substring_map = {
     "local-connection-server": [
         "errorlog: -",
         "Worker with pid \\d+ was terminated due to signal",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PP/JCF
     ],
     "listrev": ["connect: Connection refused"]
 }


### PR DESCRIPTION
# Description

We have noticed occasional error messages like the following in regression test logfiles:
```
pytest-9439/run4/log_biery_lr-session_local-connection-server.txt:[2025-11-04 10:59:16 -0600] [3574082] [ERROR] Worker (pid:3574083) was sent SIGHUP!
```

Primarily these messages appear in the connectivity server log file, but occasionally they appear in the root controller log file.

Claudia provided a fix for the connectivity server occurrences of the problem in DUNE-DAQ/daqsystemtest#259.  That fix slightly changes the commands that we use to start up and shut down the connectivity server.

This PR in the `listrev` repo copies those changes to the ConnSrvr startup/shutdown to the `listrev_test`.

To these these changes, one would simply run the `listrev_test.py` and confirm that it completes without any complaints.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
