### PR TITLE
Changes to bring the listrev_test integtest up to date

### DIFF
--- a/config/listrev-objects.data.xml
+++ b/config/listrev-objects.data.xml
@@ -91,7 +91,7 @@
  <attr name="commandline_parameters" type="string">
   <data val="Process PID $$;"/>
   <data val="trap &apos;pkill -QUIT -P $$&apos; EXIT;"/>
-  <data val="setsid gunicorn -b 0.0.0.0:25000 --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
+  <data val="setsid gunicorn -b 0.0.0.0:${CONNECTION_PORT} --workers=1 --worker-class=gthread --threads=2 --timeout 5000000000 --log-level=info connectivityserver.connectionflask:app"/>
  </attr>
  <attr name="threads" type="u16" val="1"/>
  <rel name="runs_on" class="VirtualHost" id="vlocalhost"/>
@@ -105,6 +105,11 @@
  <attr name="interval_ms" type="u32" val="2000"/>
  <attr name="host" type="string" val="localhost"/>
  <rel name="service" class="Service" id="local-connectivity-service"/>
+</obj>
+
+<obj class="Variable" id="local-env-connectivity-port">
+ <attr name="name" type="string" val="CONNECTION_PORT"/>
+ <attr name="value" type="string" val="25000"/>
 </obj>
 
 <obj class="DetectorConfig" id="dummy-detector">
@@ -540,6 +545,7 @@
   <ref class="Variable" id="DUNEDAQ_ERS_INFO"/>
   <ref class="Variable" id="DUNEDAQ_ERS_VERBOSITY_LEVEL"/>
   <ref class="Variable" id="DUNEDAQ_ERS_WARNING"/>
+  <ref class="Variable" id="local-env-connectivity-port"/>
  </rel>
 </obj>
 

--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -37,7 +37,6 @@ excluded_substring_map = {
 
 common_config_obj = data_classes.drunc_config()
 common_config_obj.session = "lr-session"
-common_config_obj.attempt_cleanup = True
 
 single_app_conf = copy.deepcopy(common_config_obj)
 single_app_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession-singleapp.data.xml"


### PR DESCRIPTION
# Description

In running various tests as we near the end of the `fddaq-v5.5.0` development cycle, I noticed two mis-behaviors from the regression test in this package (`listrev_test.py`).

The first was an error message at the start of each subtest like the following:

```
Found free Kubernetes NodePort: 32017
Updated Connectivity Service 'local-connectivity-service' to use port 32017
Error: Could not find a 'CONNECTION_PORT' variable in the session's environment.
Found free Kubernetes NodePort: 31174
Updated RC Controller Service 'root-controller-single_control' to use port 31174
Successfully configured RC controller port for session 'lr-session'.
```

I believe that this is because we hadn't yet copied the use of a CONNECTION_PORT session env var to the `listrev` configs.  Changes in this PR attempt to do that (and they avoid the error mesage).

The second misbehavior was collision between the running of the `listrev_test` and running of other regression tests at the same time on the same computer with the same user account.  When I would do that, the other regression tests would abruptly stop.

I believe that this was because of a leftover configuration setting that was telling the integrationtest infrastructure to kill all `gunicorn` and `drunc` processes at the end of each `listrev_test` drunc session.  I've removed that configuration setting, and `listrev_test` now plays nicely with other tests.

To test these changes, one should check that there are no error messages at the start of each sub-test (and the connectivity server port is set correctly in the configuration) and check that the `listrev_test` doesn't clobber other tests running at the same time.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
