### PR TITLE
Removed sighup filters, ready for testing

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -23,7 +23,6 @@ excluded_substring_map = {
         'ERROR.*Broadcast:.*Propagating describe to children',
         'WARNING.*Broadcast:.*There is no broadcasting service!',
         "Worker with pid \\d+ was terminated due to signal",
-        r"Worker \(pid:\d+\) was sent SIGHUP"  # ignoring SIGHUP messages pending investigation, 03-Nov, KAB/PP/JCF
     ],
     "local-connection-server": [
         "errorlog: -",


### PR DESCRIPTION
# Description
Undoes the changes introduced in https://github.com/DUNE-DAQ/listrev/pull/112/files, with the resolution of the connectivity service no longer getting SIGHUP
Part of https://github.com/DUNE-DAQ/daqsystemtest/pull/259

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

