### PR TITLE
NanoRC to DuneRC name change

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -80,7 +80,7 @@ def test_dunerc_success(run_dunerc):
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
     if match_obj:
         current_test = match_obj.group(1)
-    current_test += ": NanoRC Success Check"
+    current_test += ": DuneRC Success Check"
     banner_line = re.sub(".", "=", current_test)
     print()
     print(banner_line)

--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -64,8 +64,8 @@ confgen_arguments = {
     "Multiple Generators": multigen_conf,
     "Large System": large_conf,
 }
-# The commands to run in nanorc, as a list
-nanorc_command_list = (
+# The commands to run in dunerc, as a list
+dunerc_command_list = (
     "boot wait 5 conf start wait 1 enable-triggers wait ".split()
     + [str(run_duration)]
     + "disable-triggers wait 2 drain-dataflow wait 2 stop-trigger-sources stop scrap terminate".split()
@@ -74,7 +74,7 @@ nanorc_command_list = (
 # The tests themselves
 
 
-def test_nanorc_success(run_nanorc):
+def test_dunerc_success(run_dunerc):
     # print the name of the current test
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
@@ -87,11 +87,11 @@ def test_nanorc_success(run_nanorc):
     print(current_test)
     print(banner_line)
 
-    # Check that nanorc completed correctly
-    assert run_nanorc.completed_process.returncode == 0
+    # Check that dunerc completed correctly
+    assert run_dunerc.completed_process.returncode == 0
 
 
-def test_log_files(run_nanorc):
+def test_log_files(run_dunerc):
     current_test = os.environ.get("PYTEST_CURRENT_TEST")
     match_obj = re.search(r".*\[(.+)-run_.*rc.*\d].*", current_test)
     if match_obj:
@@ -105,7 +105,7 @@ def test_log_files(run_nanorc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_nanorc.log_files, excluded_substring_map=excluded_substring_map
+            run_dunerc.log_files, excluded_substring_map=excluded_substring_map
         )
 
     # Exiting do_stop() method, generated 2081 lists, and sent 2081 list messages DAQModule: rdlg0
@@ -119,8 +119,8 @@ def test_log_files(run_nanorc):
     validator_received_reversed = 0
     validator_errors = 999
 
-    for idx in range(len(run_nanorc.log_files)):
-        for line in open(run_nanorc.log_files[idx], errors='ignore').readlines():
+    for idx in range(len(run_dunerc.log_files)):
+        for line in open(run_dunerc.log_files[idx], errors='ignore').readlines():
             if "Exiting do_stop" in line:
                 if "RandomDataListGenerator" in line:
                     m = re.search(


### PR DESCRIPTION
# Description

These changes follow along with the ones in DUNE-DAQ/integrationtest#147.  They convert the obsolete "nanorc" name in our integration tests to a more generic "dunerc" name.

Other than observing the new "dunerc" name in the integtest output, users should not notice a difference, and all integtests in this repo should continue to work

Here are suggestions for testing the changes:

```
DATE_PREFIX=`date '+%d%b'`
TIME_SUFFIX=`date '+%H%M'`

source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -n NFD_DEV_260311_A9 ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}
cd ${DATE_PREFIX}FDDevTest_${TIME_SUFFIX}/sourcecode

git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/listrev.git -b kbiery/nanorc_to_dunerc_name_change
cd ..

dbt-workarea-env
dbt-build -j 12
dbt-workarea-env

dunedaq_integtest_bundle.sh -r listrev --concise

echo ""
echo -e "\U1F535 \U2705 Note that all of the modified integtests passed. \U2705 \U1F535"
echo ""
echo ""
```

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
