### PR TITLE
Modified the integtest to reflect changes in the names of the drunc_config "session" parameters

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -35,7 +35,7 @@ excluded_substring_map = {
 # output directory (the test framework handles that)
 
 common_config_obj = data_classes.drunc_config()
-common_config_obj.session = "lr-session"
+common_config_obj.config_session_name = "lr-session"
 
 single_app_conf = copy.deepcopy(common_config_obj)
 single_app_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession-singleapp.data.xml"


### PR DESCRIPTION
# Description

These changes are intended to be included in `fddaq-v5.7.0`...

As described in DUNE-DAQ/integrationtest#153, I believe that there is value in making the names of the session-based parameters in our `integrationtest` `drunc_config` data structure more clear.  The changes in this PR reflect the new names that are part of DUNE-DAQ/integrationtest#153.  Please see the `integrationtest` PR for more details, including suggested instructions for testing the changes.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
