### PR TITLE
initial changes to adapt to confgen (integtest config params) improvements

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -39,26 +39,26 @@ excluded_substring_map = {
 # The arguments to pass to the config generator, excluding the json
 # output directory (the test framework handles that)
 
-common_config_obj = data_classes.drunc_config()
+common_config_obj = data_classes.integtest_params_for_predefined_dunedaq_config()
 common_config_obj.config_session_name = "lr-session"
 
 single_app_conf = copy.deepcopy(common_config_obj)
-single_app_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession-singleapp.data.xml"
+single_app_conf.predefined_config_db = os.path.dirname(__file__) + "/../config/lrSession-singleapp.data.xml"
 v_conf = copy.deepcopy(common_config_obj)
-v_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession-v.data.xml"
+v_conf.predefined_config_db = os.path.dirname(__file__) + "/../config/lrSession-v.data.xml"
 g_conf = copy.deepcopy(common_config_obj)
-g_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession-g.data.xml"
+g_conf.predefined_config_db = os.path.dirname(__file__) + "/../config/lrSession-g.data.xml"
 r_conf = copy.deepcopy(common_config_obj)
-r_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession-r.data.xml"
+r_conf.predefined_config_db = os.path.dirname(__file__) + "/../config/lrSession-r.data.xml"
 separate_conf = copy.deepcopy(common_config_obj)
-separate_conf.config_db = (
+separate_conf.predefined_config_db = (
     os.path.dirname(__file__) + "/../config/lrSession-separate.data.xml"
 )
 multigen_conf = copy.deepcopy(common_config_obj)
-multigen_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession-gg.data.xml"
+multigen_conf.predefined_config_db = os.path.dirname(__file__) + "/../config/lrSession-gg.data.xml"
 
 large_conf = copy.deepcopy(common_config_obj)
-large_conf.config_db = os.path.dirname(__file__) + "/../config/lrSession.data.xml"
+large_conf.predefined_config_db = os.path.dirname(__file__) + "/../config/lrSession.data.xml"
 
 confgen_arguments = {
     "Single App": single_app_conf,


### PR DESCRIPTION
# Description

These changes are intended for `fddaq-v5.7.0`.

They need to be tested and merged in conjunction with DUNE-DAQ/integrationtest#155 and branches in other repositories.  Please see the `integrationtest` PR for suggested testing instructions.

The changes in this repository react to, and take advantage of, changes in the `integrationtest` infrastructure that attempt to make it easier to specify and understand the parameters that drive each test. 

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
