### PR TITLE
Modified the integtest to use the new utility_functions module from the integrationtest repo instead of the basic_checks module.

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -5,8 +5,8 @@ import urllib.request
 import copy
 
 import integrationtest.log_file_checks as log_file_checks
-import integrationtest.basic_checks as basic_checks
 import integrationtest.data_classes as data_classes
+import integrationtest.utility_functions as utility_functions
 from integrationtest.verbosity_helper import IntegtestVerbosityLevels
 
 import functools
@@ -81,7 +81,7 @@ dunerc_command_list = (
 
 def test_dunerc_success(run_dunerc, caplog):
     # check for run control success, problems during pytest setup, etc.
-    basic_checks.basic_checks(run_dunerc, caplog, print_test_name=True)
+    utility_functions.basic_checks(run_dunerc, caplog, print_test_name=True)
 
 
 def test_log_files(run_dunerc):


### PR DESCRIPTION
# Description

The ability to remove HDF5 files at the end of each integtest (upon user request) was suggested some time ago in discussions about changes to the `integrationtest` infrastructure.  The `integrationtest` code has been modified to support this functionality (DUNE-DAQ/integrationtest#157), and the changes in this PR react to those changes.

These changes should be tested and merged in conjunction with the changes in the `integrationtest` and other repos.  Please see DUNE-DAQ/integrationtest#157 for suggested testing steps.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
