### PR TITLE
When list has no pending entry in ListReverser issue a warnig saying so

### DIFF
--- a/plugins/ListReverser.cpp
+++ b/plugins/ListReverser.cpp
@@ -205,12 +205,9 @@ ListReverser::process_list(const IntList& list)
   TLOG_DEBUG(TLVL_LIST_REVERSAL) << get_name() << ": Received list #" << list.list_id << " from " << list.generator_id
                                  << ". It has size " << list.list.size() << ". Reversing its contents";
 
-  if (m_pending_lists.count(list.list_id) == 0) {
-
-    std::ostringstream oss_warn;
-    oss_warn << "send " << list.list_id << " to \"" << m_pending_lists[list.list_id].requestor
-             << "\" (late list receive)";
-    ers::warning(dunedaq::iomanager::TimeoutExpired(ERS_HERE, get_name(), oss_warn.str(), m_send_timeout.count()));
+  if (!m_pending_lists.contains(list.list_id)) {
+    ers::warning(UnexpectedListError(
+                   ERS_HERE, get_name(), list.list_id, list.generator_id));
     return;
   }
 
@@ -229,10 +226,13 @@ ListReverser::process_list(const IntList& list)
            << " and size " << workingVector.size() << ". ";
   TLOG_DEBUG() << ProgressUpdate(ERS_HERE, get_name(), oss_prog.str());
 
+  auto request_age = std::chrono::duration_cast<std::chrono::milliseconds>(
+  std::chrono::steady_clock::now() - m_pending_lists[list.list_id].start_time);
   if (m_pending_lists[list.list_id].list.lists.size() >= m_generator_connections.size() ||
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - m_pending_lists[list.list_id].start_time) > m_request_timeout) {
-
+       request_age > m_request_timeout) {
+    if (m_pending_lists[list.list_id].list.lists.size() < m_generator_connections.size()) {
+      TLOG_DEBUG(TLVL_LIST_REVERSAL) << get_name() << " processing list " << list.list_id << " with only " << m_pending_lists[list.list_id].list.lists.size() << " parts after " << request_age << " (req timeout " << m_request_timeout << ")";
+    }
     bool successfullyWasSent = false;
     int failCount = 0;
     while (!successfullyWasSent && failCount < 100) {

--- a/plugins/ListReverser.hpp
+++ b/plugins/ListReverser.hpp
@@ -30,7 +30,8 @@
 #include <string>
 #include <vector>
 
-namespace dunedaq::listrev {
+namespace dunedaq {
+namespace listrev {
 
 /**
  * @brief ListReverser reads lists of integers from one queue,
@@ -104,7 +105,16 @@ private:
   std::atomic<uint64_t> m_total_lists_received{ 0 };    // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_total_lists_sent{ 0 };        // NOLINT(build/unsigned)
 };
-} // namespace dunedaq::listrev
+} // namespace listrev
+
+// Disable coverage collection LCOV_EXCL_START
+ERS_DECLARE_ISSUE(listrev,
+                  UnexpectedListError,
+                  name << " received list id " << id << " from " << generator <<  " with no pending request",
+                  ((std::string)name)((int)id)((int)generator)) // NOLINT(readability/casting)
+// Re-enable coverage collection LCOV_EXCL_STOP
+
+} // namespace dunedaq
 
 #endif // LISTREV_PLUGINS_LISTREVERSER_HPP_
 


### PR DESCRIPTION
# Description

The current code in `ListReverser` checks if there is an entry in the pending map for a list it has just received. Howerver, the action it takes in the case there is no entry is wrong. It will try to issue a warning about a timeout rather than a missing map entry and in the process it will actually create a phantom entry in the map which will cause the later code to try and send the list to destination "". This fix outputs an explicit `UnexpectedListError` ERS Issue instead.

To test, in a session with multiple `RandomDataListGenerators`, set the `request_timeout_ms` attribute of the `ListReverser` to a very low value (e.g. 1). This will cause pending requests to be sent and cleared before all parts have been received.

In the existing code, this will cause messages like this in the log file
```
2026-Jul-14 09:50:33,002 WARNING [void dunedaq::listrev::ListReverser::process_list(const dunedaq::listrev::IntList&) at /home/gjc/DUNE/NFD_DEV_260706_A9/sourcecode/listrev/plugins/ListReverser.cpp:213] lr0: Unable to send 2 to "" (late list receive) within timeout period (timeout period was 1000 milliseconds)
```
Followed by a never ending repetition of
```
2026-Jul-14 09:50:35,006 WARNING [void dunedaq::listrev::ListReverser::process_list(const dunedaq::listrev::IntList&) at /home/gjc/DUNE/NFD_DEV_260706_A9/sourcecode/listrev/plugins/ListReverser.cpp:251] lr0: Unable to send 2 to "" within timeout period (timeout period was 1000 milliseconds)
2026-Jul-14 09:50:36,007 WARNING [void dunedaq::listrev::ListReverser::process_list(const dunedaq::listrev::IntList&) at /home/gjc/DUNE/NFD_DEV_260706_A9/sourcecode/listrev/plugins/ListReverser.cpp:251] lr0: Unable to send 2 to "" within timeout period (timeout period was 1000 milliseconds)
```

Try the same with the code in this PR and you should see
```
2026-Jul-14 09:57:31,444 WARNING [void dunedaq::listrev::ListReverser::process_list(const dunedaq::listrev::IntList&) at /home/gjc/DUNE/NFD_DEV_260706_A9/sourcecode/listrev/plugins/ListReverser.cpp:210] lr0 received list id 2 from 2 with no pending request
```


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

