### PR TITLE
Defer any access to DAL until conf transition. Just take a copy of th…

### DIFF
--- a/plugins/ListReverser.cpp
+++ b/plugins/ListReverser.cpp
@@ -43,6 +43,7 @@ namespace dunedaq::listrev {
 ListReverser::ListReverser(const std::string& name)
   : DAQModule(name)
 {
+  register_command("conf", &ListReverser::do_conf);
   register_command("start", &ListReverser::do_start);
   register_command("stop", &ListReverser::do_stop);
 }
@@ -51,7 +52,16 @@ void
 ListReverser::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
-  auto mdal = mcfg->get_dal<dal::ListReverser>(get_name());
+  m_cfg_mgr = mcfg;
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
+}
+
+void
+ListReverser::do_conf(const CommandData_t& /*startobj*/)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_conf() method";
+
+  auto mdal = m_cfg_mgr->get_dal<dal::ListReverser>(get_name());
   for (auto con : mdal->get_inputs()) {
     if (con->get_data_type() == datatype_to_string<IntList>()) {
       m_list_connection = con->UID();
@@ -87,7 +97,7 @@ ListReverser::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
                              << mdal->get_request_timeout_ms() << "ms, " << " and " << m_generator_connections.size()
                              << " generators.";
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting conf() method";
 }
 
 void

--- a/plugins/ListReverser.hpp
+++ b/plugins/ListReverser.hpp
@@ -57,6 +57,7 @@ protected:
 
 private:
   // Commands
+  void do_conf(const CommandData_t& obj);
   void do_start(const CommandData_t& obj);
   void do_stop(const CommandData_t& obj);
 
@@ -84,10 +85,12 @@ private:
   mutable std::mutex m_map_mutex;
 
   // Init
+  std::shared_ptr<appfwk::ConfigurationManager> m_cfg_mgr;
+
+  // Configuration
   std::string m_requests;
   std::string m_list_connection;
 
-  // Configuration
   std::chrono::milliseconds m_send_timeout{ 100 };
   std::chrono::milliseconds m_request_timeout{ 1000 };
   size_t m_reverser_id{ 0 };

--- a/plugins/RandomDataListGenerator.cpp
+++ b/plugins/RandomDataListGenerator.cpp
@@ -52,7 +52,30 @@ void
 RandomDataListGenerator::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
-  auto mdal = mcfg->get_dal<dal::RandomDataListGenerator>(get_name());
+
+  m_cfg_mgr = mcfg;
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
+}
+
+void
+RandomDataListGenerator::generate_opmon_data()
+{
+  opmon::RandomListGeneratorInfo fcr;
+
+  fcr.set_generated_numbers(m_generated_tot.load());
+  fcr.set_new_generated_numbers(m_generated.exchange(0));
+  fcr.set_lists_sent(m_sent_tot.load());
+  fcr.set_new_lists_sent(m_sent.exchange(0));
+
+  publish(std::move(fcr));
+}
+
+void
+RandomDataListGenerator::do_conf(const CommandData_t& /*args*/)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_conf() method";
+
+  auto mdal = m_cfg_mgr->get_dal<dal::RandomDataListGenerator>(get_name());
 
   if (mdal == nullptr) {
     throw appfwk::CommandFailed(ERS_HERE, get_name(), "init", "Unable to load module configuration");
@@ -78,28 +101,8 @@ RandomDataListGenerator::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg
   m_list_mode =
     static_cast<ListMode>(m_generator_id % (static_cast<uint16_t>(ListMode::MAX) + 1)); // NOLINT(build/unsigned)
 
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
-}
 
-void
-RandomDataListGenerator::generate_opmon_data()
-{
-  opmon::RandomListGeneratorInfo fcr;
 
-  fcr.set_generated_numbers(m_generated_tot.load());
-  fcr.set_new_generated_numbers(m_generated.exchange(0));
-  fcr.set_lists_sent(m_sent_tot.load());
-  fcr.set_new_lists_sent(m_sent.exchange(0));
-
-  publish(std::move(fcr));
-}
-
-void
-RandomDataListGenerator::do_conf(const CommandData_t& /*args*/)
-{
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_conf() method";
-
-  auto iom = iomanager::IOManager::get();
   // Add this callback early as this is a pub/sub connection
   iom->add_callback<CreateList>(m_create_connection,
                                 get_name(),

--- a/plugins/RandomDataListGenerator.hpp
+++ b/plugins/RandomDataListGenerator.hpp
@@ -67,6 +67,9 @@ private:
   void process_request_list(const RequestList& request_list);
 
   // Init
+  std::shared_ptr<appfwk::ConfigurationManager> m_cfg_mgr;
+
+
   std::string m_request_connection;
   std::string m_create_connection;
 

--- a/plugins/ReversedListValidator.cpp
+++ b/plugins/ReversedListValidator.cpp
@@ -44,6 +44,7 @@ ReversedListValidator::ReversedListValidator(const std::string& name)
   : DAQModule(name)
   , m_work_thread(std::bind(&ReversedListValidator::do_work, this, std::placeholders::_1))
 {
+  register_command("conf", &ReversedListValidator::do_conf);
   register_command("start", &ReversedListValidator::do_start);
   register_command("stop", &ReversedListValidator::do_stop);
 }
@@ -53,7 +54,18 @@ ReversedListValidator::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
 
-  auto mdal = mcfg->get_dal<dal::ReversedListValidator>(get_name());
+  m_cfg_mgr = mcfg;
+
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
+}
+
+
+void
+ReversedListValidator::do_conf(const CommandData_t& /*args*/)
+{
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_conf() method";
+
+  auto mdal = m_cfg_mgr->get_dal<dal::ReversedListValidator>(get_name());
   for (auto con : mdal->get_inputs()) {
     if (con->get_data_type() == datatype_to_string<ReversedList>()) {
       m_list_connection = con->UID();
@@ -84,11 +96,14 @@ ReversedListValidator::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
   m_request_timeout = std::chrono::milliseconds(mdal->get_request_timeout_ms());
   m_max_outstanding_requests = mdal->get_max_outstanding_requests();
 
+  m_request_rate_hz = mdal->get_request_rate_hz();
+
   m_list_creator =
     ListCreator(m_create_connection, m_send_timeout, mdal->get_min_list_size(), mdal->get_max_list_size());
-
-  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
+  TLOG() << get_name() << " successfully configured";
+  TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_conf() method";
 }
+
 
 void
 ReversedListValidator::generate_opmon_data()

--- a/plugins/ReversedListValidator.hpp
+++ b/plugins/ReversedListValidator.hpp
@@ -60,6 +60,7 @@ protected:
 
 private:
   // Commands
+  void do_conf(const CommandData_t& obj);
   void do_start(const CommandData_t& obj);
   void do_stop(const CommandData_t& obj);
 
@@ -93,10 +94,11 @@ private:
   ListCreator m_list_creator;
 
   // Init
-  std::string m_list_connection;
-  std::string m_create_connection;
+  std::shared_ptr<appfwk::ConfigurationManager> m_cfg_mgr;
 
   // Configuration
+  std::string m_list_connection;
+  std::string m_create_connection;
   std::chrono::milliseconds m_send_timeout{ 100 };
   std::chrono::milliseconds m_request_timeout{ 1000 };
   size_t m_max_outstanding_requests{ 100 };


### PR DESCRIPTION
# Description

Defer any access to DAL until conf transition. Just take a copy of the config manager pointer at init. This allows for the configuration to be reloaded before conf which would invalidate any dal object pointers.



## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

