### PR TITLE
Added the verbosity_helper to the log_file_checks call in listrev_test…

### DIFF
--- a/integtest/listrev_test.py
+++ b/integtest/listrev_test.py
@@ -88,7 +88,8 @@ def test_log_files(run_dunerc):
     if check_for_logfile_errors:
         # Check that there are no warnings or errors in the log files
         assert log_file_checks.logs_are_error_free(
-            run_dunerc.log_files, excluded_substring_map=excluded_substring_map
+            run_dunerc.log_files, excluded_substring_map=excluded_substring_map,
+            verbosity_helper=run_dunerc.verbosity_helper
         )
 
     # Exiting do_stop() method, generated 2081 lists, and sent 2081 list messages DAQModule: rdlg0


### PR DESCRIPTION
…so that it respects the verbosity level that a user requests.

# Description

Without this, logfile test summaries get printed out even when the user has requested a low verbosity level.

To test this, run `dunedaq_integtest_bundle.sh --verb 2 -r listrev` without using this branch and notice that there are messages displayed on the console like the following:

```
.🚧 Note: problems found in 52 lines in /tmp/pytest-of-biery/pytest-16059/run2/log_biery_drunc_console_output.txt were ignored based on 18 phrase(s). 🚧
```

With this branch, those messages are suppressed, as they should be at verbosity level 2.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
